### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Allows you to run this app easily as a docker container.
+# See README.md for more details.
+#
+# 1. Build the image with: docker build --no-cache -t test/vaadinplus:latest --build-arg offlinekey='key' .
+# 2. Run the image with: docker run --rm -ti -p8080:8080 test/vaadinplus
+#
+# Uses Docker Multi-stage builds: https://docs.docker.com/build/building/multi-stage/
+
+# The "Build" stage. Copies the entire project into the container, into the /app/ folder, and builds it.
+FROM eclipse-temurin:17 AS BUILD
+COPY . /app/
+WORKDIR /app/
+ARG offlinekey
+ENV VAADIN_OFFLINE_KEY=$offlinekey
+RUN ./mvnw clean test package -Pproduction
+# At this point, we have the app (executable jar file):  /app/target/vaadinplus-1.0-SNAPSHOT.jar
+
+# The "Run" stage. Start with a clean image, and copy over just the app itself, omitting gradle, npm and any intermediate build files.
+FROM eclipse-temurin:17
+COPY --from=BUILD /app/target/vaadinplus-1.0-SNAPSHOT.jar /app/
+WORKDIR /app/
+EXPOSE 8080
+ENTRYPOINT java -jar vaadinplus-1.0-SNAPSHOT.jar 8080
+


### PR DESCRIPTION
Dockerfile is required in order for your project to be hosted at v-herd.eu.

Please note that the project fails to start in production mode at the moment:
```
2023-06-02T14:08:31.958Z ERROR 7 --- [nio-8080-exec-4] c.v.flow.router.InternalServerError      : There was an exception while trying to navigate to ''

com.vaadin.flow.component.sidenav.ExperimentalFeatureException: The SideNav component is currently an experimental feature and needs to be explicitly enabled. The component can be enabled using the Vaadin dev-mode Gizmo, in the experimental features tab, or by adding a `src/main/resources/vaadin-featureflags.properties` file with the following content: `com.vaadin.experimental.sideNavComponent=true`
	at com.vaadin.flow.component.sidenav.SideNavItem.checkFeatureFlag(SideNavItem.java:263) ~[vaadin-side-nav-flow-24.1.0.beta2.jar!/:na]
	at com.vaadin.flow.component.sidenav.SideNavItem.onAttach(SideNavItem.java:247) ~[vaadin-side-nav-flow-24.1.0.beta2.jar!/:na]
	at com.vaadin.flow.component.ComponentUtil.onComponentAttach(ComponentUtil.java:232) ~[flow-server-24.1.0.beta2.jar!/:24.1.0.beta2]
```
This needs to be solved before we publish the project at v-herd.eu